### PR TITLE
SDIT-1336 Go back to old api URL properties - it's established and it works fine

### DIFF
--- a/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/config/WebClientConfiguration.kt
+++ b/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/config/WebClientConfiguration.kt
@@ -11,8 +11,8 @@ import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${prison-api.base-uri}") val prisonApiBaseUri: String,
-  @Value("\${hmpps-auth.base-uri}") val hmppsAuthBaseUri: String,
+  @Value("\${api.base.url.prison-api}") val prisonApiBaseUri: String,
+  @Value("\${api.base.url.hmpps-auth}") val hmppsAuthBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:20s}") val timeout: Duration,
 ) {

--- a/test-app-reactive/src/main/resources/application.yml
+++ b/test-app-reactive/src/main/resources/application.yml
@@ -17,12 +17,12 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${hmpps-auth.base-uri}/.well-known/jwks.json
+          jwk-set-uri: ${api.base.url.hmpps-auth}/.well-known/jwks.json
 
       client:
         provider:
           hmpps-auth:
-            token-uri: ${hmpps-auth.base-uri}/oauth/token
+            token-uri: ${api.base.url.hmpps-auth}/oauth/token
 
         registration:
           prison-api:

--- a/test-app-reactive/src/test/resources/application-test.yml
+++ b/test-app-reactive/src/test/resources/application-test.yml
@@ -5,11 +5,11 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
-hmpps-auth:
-  base-uri: http://localhost:8090/auth
+api.base.url:
+  hmpps-auth: http://localhost:8090/auth
+  prison-api: http://localhost:8091
 
 prison-api:
-  base-uri: http://localhost:8091
   client:
     id: prison-api-client
     secret: prison-api-client-secret

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/config/WebClientConfiguration.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/config/WebClientConfiguration.kt
@@ -11,8 +11,8 @@ import java.time.Duration
 
 @Configuration
 class WebClientConfiguration(
-  @Value("\${prison-api.base-uri}") val prisonApiBaseUri: String,
-  @Value("\${hmpps-auth.base-uri}") val hmppsAuthBaseUri: String,
+  @Value("\${api.base.url.prison-api}") val prisonApiBaseUri: String,
+  @Value("\${api.base.url.hmpps-auth}") val hmppsAuthBaseUri: String,
   @Value("\${api.health-timeout:2s}") val healthTimeout: Duration,
   @Value("\${api.timeout:20s}") val timeout: Duration,
 ) {

--- a/test-app/src/main/resources/application.yml
+++ b/test-app/src/main/resources/application.yml
@@ -17,12 +17,12 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${hmpps-auth.base-uri}/.well-known/jwks.json
+          jwk-set-uri: ${api.base.url.hmpps-auth}/.well-known/jwks.json
 
       client:
         provider:
           hmpps-auth:
-            token-uri: ${hmpps-auth.base-uri}/oauth/token
+            token-uri: ${api.base.url.hmpps-auth}/oauth/token
 
         registration:
           prison-api:

--- a/test-app/src/test/resources/application-test.yml
+++ b/test-app/src/test/resources/application-test.yml
@@ -5,11 +5,11 @@ management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
 
-hmpps-auth:
-  base-uri: http://localhost:8090/auth
+api.base.url:
+  hmpps-auth: http://localhost:8090/auth
+  prison-api: http://localhost:8091
 
 prison-api:
-  base-uri: http://localhost:8091
   client:
     id: prison-api-client
     secret: prison-api-client-secret


### PR DESCRIPTION
And it means you can do things like [this](https://github.com/ministryofjustice/hmpps-prisoner-to-nomis-update/blob/main/helm_deploy/values-prod.yaml#L12) and [this](https://github.com/ministryofjustice/hmpps-prisoner-to-nomis-update/blob/main/src/test/resources/application-test.yml#L8). Which are easier to digest.