### PR TITLE
INC-1355 Add subject access request reactive services and tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "0.2.1"
+  version = "0.2.2"
 
   repositories {
     mavenCentral()

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/sar/HmppsSubjectAccessRequestReactiveController.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/sar/HmppsSubjectAccessRequestReactiveController.kt
@@ -1,0 +1,113 @@
+package uk.gov.justice.hmpps.kotlin.sar
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
+import java.time.LocalDate
+
+/**
+ * Prisoners have the right to access and receive a copy of their personal data and other supplementary information.
+ *
+ * This is commonly referred to as a subject access request or ‘SAR’.
+ */
+@Suppress("SpringJavaInjectionPointsAutowiringInspection")
+@RestController
+@Tag(name = "Subject Access Request")
+@PreAuthorize("hasAnyRole('SAR_DATA_ACCESS', @environment.getProperty('hmpps.sar.additionalAccessRole', 'SAR_DATA_ACCESS'))")
+@RequestMapping("/subject-access-request", produces = [MediaType.APPLICATION_JSON_VALUE])
+@ConditionalOnBean(HmppsSubjectAccessRequestReactiveService::class)
+class HmppsSubjectAccessRequestReactiveController(private val service: HmppsSubjectAccessRequestReactiveService) {
+
+  @GetMapping
+  @Operation(
+    summary = "Provides content for a prisoner to satisfy the needs of a subject access request on their behalf",
+    description = "Requires role SAR_DATA_ACCESS or additional role as specified by hmpps.sar.additionalAccessRole configuration.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Request successfully processed - content found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = HmppsSubjectAccessRequestContent::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "204",
+        description = "Request successfully processed - no content found",
+      ),
+      ApiResponse(
+        responseCode = "209",
+        description = "Subject Identifier is not recognised by this service",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The client does not have authorisation to make this request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "500",
+        description = "Unexpected error occurred",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  suspend fun getSarContentByReference(
+    @RequestParam(name = "prn")
+    @Parameter(description = "NOMIS Prison Reference Number")
+    prn: String?,
+    @RequestParam(name = "crn")
+    @Parameter(description = "nDelius Case Reference Number")
+    crn: String?,
+    @RequestParam(value = "fromDate")
+    @Parameter(description = "Optional parameter denoting minimum date of event occurrence which should be returned in the response")
+    fromDate: LocalDate?,
+    @RequestParam(value = "toDate")
+    @Parameter(description = "Optional parameter denoting maximum date of event occurrence which should be returned in the response")
+    toDate: LocalDate?,
+  ): ResponseEntity<Any> {
+    if (prn.isNullOrBlank() && crn.isNullOrBlank()) {
+      return ResponseEntity.badRequest().body(
+        ErrorResponse(
+          status = HttpStatus.BAD_REQUEST,
+          userMessage = "One of prn or crn must be supplied.",
+          developerMessage = "One of prn or crn must be supplied.",
+        ),
+      )
+    }
+
+    val content = if (service is HmppsPrisonSubjectAccessRequestReactiveService && !prn.isNullOrBlank()) {
+      service.getPrisonContentFor(prn, fromDate, toDate)
+    } else if (service is HmppsProbationSubjectAccessRequestReactiveService && !crn.isNullOrBlank()) {
+      service.getProbationContentFor(crn, fromDate, toDate)
+    } else if (service is HmppsPrisonProbationSubjectAccessRequestReactiveService) {
+      service.getContentFor(prn, crn, fromDate, toDate)
+    } else {
+      return ResponseEntity.status(209).build()
+    }
+
+    return content?.let { ResponseEntity.ok(it) } ?: ResponseEntity.noContent().build()
+  }
+}

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/sar/HmppsSubjectAccessRequestReactiveService.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/sar/HmppsSubjectAccessRequestReactiveService.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.hmpps.kotlin.sar
+
+import java.time.LocalDate
+
+interface HmppsSubjectAccessRequestReactiveService
+
+/**
+ * Interface to be implemented if service only handles Prisoner Reference Numbers aka Prison Number.
+ */
+interface HmppsPrisonSubjectAccessRequestReactiveService : HmppsSubjectAccessRequestReactiveService {
+  suspend fun getPrisonContentFor(prn: String, fromDate: LocalDate?, toDate: LocalDate?): HmppsSubjectAccessRequestContent?
+}
+
+/**
+ * Interface to be implemented if service only handles Case Reference Numbers
+ */
+interface HmppsProbationSubjectAccessRequestReactiveService : HmppsSubjectAccessRequestReactiveService {
+  suspend fun getProbationContentFor(crn: String, fromDate: LocalDate?, toDate: LocalDate?): HmppsSubjectAccessRequestContent?
+}
+
+/**
+ * Interface to be implemented if service handles both Prisoner Reference Numbers and Case Reference Numbers
+ */
+interface HmppsPrisonProbationSubjectAccessRequestReactiveService : HmppsSubjectAccessRequestReactiveService {
+  suspend fun getContentFor(prn: String?, crn: String?, fromDate: LocalDate?, toDate: LocalDate?): HmppsSubjectAccessRequestContent?
+}

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -3,3 +3,4 @@ uk.gov.justice.hmpps.kotlin.auth.HmppsReactiveResourceServerConfiguration
 uk.gov.justice.hmpps.kotlin.auth.HmppsWebClientConfiguration
 uk.gov.justice.hmpps.kotlin.auth.HmppsReactiveWebClientConfiguration
 uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestController
+uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestReactiveController

--- a/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/service/SubjectAccessRequestService.kt
+++ b/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/service/SubjectAccessRequestService.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.testappreactive.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestReactiveService
+import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
+import java.time.LocalDate
+
+@Service
+class SubjectAccessRequestService() : HmppsPrisonSubjectAccessRequestReactiveService {
+  override suspend fun getPrisonContentFor(prn: String, fromDate: LocalDate?, toDate: LocalDate?) =
+    prn.takeIf { prn.startsWith("A") }?.let {
+      HmppsSubjectAccessRequestContent(
+        content = TestContent(
+          prisonerNumber = prn,
+          commentText = "some useful comment",
+        ),
+      )
+    }
+}
+
+data class TestContent(
+  val prisonerNumber: String,
+  val commentText: String,
+)

--- a/test-app-reactive/src/main/resources/application.yml
+++ b/test-app-reactive/src/main/resources/application.yml
@@ -63,3 +63,7 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+hmpps:
+  sar:
+    additionalAccessRole: TEST_DATA_ACCESS

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/resource/SubjectAccessRequestInternalIntegrationTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/resource/SubjectAccessRequestInternalIntegrationTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.testappreactive.integration.resource
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.testappreactive.integration.IntegrationTestBase
+
+/**
+ * This class tests the functionality of the HmppsSubjectAccessRequestController
+ *
+ * It should not be copied into other projects to test that their service implementations are
+ * correct - please see SubjectAccessRequestSampleIntegrationTest instead. Service implementations should test that
+ * the endpoint exists and their content is returned.
+ *
+ * Other scenarios such as 209 or 400 scenarions should be left to this class to test as they are subject to change.
+ */
+class SubjectAccessRequestInternalIntegrationTest : IntegrationTestBase() {
+  @Nested
+  @DisplayName("/subject-access-request")
+  inner class SubjectAccessRequestEndpoint {
+
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `should return data if prisoner exists`() {
+        // service will return data for prisoners that start with A
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.content.prisonerNumber").isEqualTo("A12345")
+          .jsonPath("$.content.commentText").isEqualTo("some useful comment")
+      }
+
+      @Test
+      fun `should return success for additional access role`() {
+        // service will return not found for prisoners that don't start with A
+        webTestClient.get().uri("/subject-access-request?prn=B12345C")
+          .headers(setAuthorisation(roles = listOf("ROLE_TEST_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isNoContent
+      }
+
+      @Test
+      fun `should return 204 if no prisoner data exists`() {
+        // service will return not found for prisoners that don't start with A
+        webTestClient.get().uri("/subject-access-request?prn=B12345C")
+          .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isNoContent
+      }
+
+      @Test
+      fun `should return success if both prn and crn supplied`() {
+        webTestClient.get().uri("/subject-access-request?prn=B12345C&crn=1234")
+          .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isNoContent
+      }
+
+      @Test
+      fun `should return 209 if no prn supplied`() {
+        webTestClient.get().uri("/subject-access-request?crn=AB12345C")
+          .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isEqualTo(209)
+      }
+
+      @Test
+      fun `should return 400 if no prn or crn supplied`() {
+        webTestClient.get().uri("/subject-access-request")
+          .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isEqualTo(400)
+      }
+    }
+  }
+}

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/resource/SubjectAccessRequestSampleIntegrationTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/resource/SubjectAccessRequestSampleIntegrationTest.kt
@@ -1,0 +1,71 @@
+package uk.gov.justice.digital.hmpps.testappreactive.integration.resource
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.testappreactive.integration.IntegrationTestBase
+
+/**
+ * Sample test to check the service implementation is picked up by the endpoint and the service access request endpoint
+ * is created.
+ *
+ * Also see SubjectAccessRequestServiceSampleTest for a sample service implementation.
+ */
+class SubjectAccessRequestSampleIntegrationTest : IntegrationTestBase() {
+  @Nested
+  @DisplayName("/subject-access-request")
+  inner class SubjectAccessRequestEndpoint {
+    @Nested
+    inner class Security {
+      @Test
+      fun `access forbidden when no authority`() {
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .exchange()
+          .expectStatus().isUnauthorized
+      }
+
+      @Test
+      fun `access forbidden when no role`() {
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf()))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+
+      @Test
+      fun `access forbidden with wrong role`() {
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf("ROLE_BANANAS")))
+          .exchange()
+          .expectStatus().isForbidden
+      }
+    }
+
+    @Nested
+    inner class HappyPath {
+      @Test
+      fun `should return data if prisoner exists`() {
+        // service will return data for prisoners that start with A
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf("ROLE_SAR_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.content.prisonerNumber").isEqualTo("A12345")
+          .jsonPath("$.content.commentText").isEqualTo("some useful comment")
+      }
+
+      @Test
+      fun `should return data for additional TEST_DATA_ACCESS role`() {
+        // service will return data for prisoners that start with A
+        webTestClient.get().uri("/subject-access-request?prn=A12345")
+          .headers(setAuthorisation(roles = listOf("ROLE_TEST_DATA_ACCESS")))
+          .exchange()
+          .expectStatus().isOk
+          .expectBody()
+          .jsonPath("$.content.prisonerNumber").isEqualTo("A12345")
+          .jsonPath("$.content.commentText").isEqualTo("some useful comment")
+      }
+    }
+  }
+}

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/service/SubjectAccessRequestReactiveServiceSampleTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/service/SubjectAccessRequestReactiveServiceSampleTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.testappreactive.integration.service
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.testappreactive.service.SubjectAccessRequestService
@@ -9,21 +9,17 @@ class SubjectAccessRequestReactiveServiceSampleTest {
   private val service = SubjectAccessRequestService()
 
   @Test
-  fun `returns null for not found`() {
-    runBlocking {
-      // service will return not found for prisoners that don't start with A
-      assertThat(service.getPrisonContentFor("B12345", null, null)).isNull()
-    }
+  fun `returns null for not found`() = runTest {
+    // service will return not found for prisoners that don't start with A
+    assertThat(service.getPrisonContentFor("B12345", null, null)).isNull()
   }
 
   @Test
-  fun `returns data if prisoner found`() {
-    runBlocking {
-      // service will return data for prisoners that start with A
-      val restrictedPatient = service.getPrisonContentFor("A12345", null, null)?.content
+  fun `returns data if prisoner found`() = runTest {
+    // service will return data for prisoners that start with A
+    val restrictedPatient = service.getPrisonContentFor("A12345", null, null)?.content
 
-      assertThat(restrictedPatient).extracting("prisonerNumber").isEqualTo("A12345")
-      assertThat(restrictedPatient).extracting("commentText").isEqualTo("some useful comment")
-    }
+    assertThat(restrictedPatient).extracting("prisonerNumber").isEqualTo("A12345")
+    assertThat(restrictedPatient).extracting("commentText").isEqualTo("some useful comment")
   }
 }

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/service/SubjectAccessRequestReactiveServiceSampleTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/service/SubjectAccessRequestReactiveServiceSampleTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.testappreactive.integration.service
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.testappreactive.service.SubjectAccessRequestService
+
+class SubjectAccessRequestReactiveServiceSampleTest {
+  private val service = SubjectAccessRequestService()
+
+  @Test
+  fun `returns null for not found`() {
+    runBlocking {
+      // service will return not found for prisoners that don't start with A
+      assertThat(service.getPrisonContentFor("B12345", null, null)).isNull()
+    }
+  }
+
+  @Test
+  fun `returns data if prisoner found`() {
+    runBlocking {
+      // service will return data for prisoners that start with A
+      val restrictedPatient = service.getPrisonContentFor("A12345", null, null)?.content
+
+      assertThat(restrictedPatient).extracting("prisonerNumber").isEqualTo("A12345")
+      assertThat(restrictedPatient).extracting("commentText").isEqualTo("some useful comment")
+    }
+  }
+}


### PR DESCRIPTION
The changes introduced new reactive services for subject access requests, catering to both prisoner reference numbers and case reference numbers. This included adding relevant tests, controllers, and service implementations with additional specifications on handling requests based on different roles and permissions. The build version was also updated to reflect these enhancements.