### PR TITLE
SDIT-2593 Add customisable security matcher

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "1.3.0"
+  version = "1.4.0-beta"
 
   repositories {
     mavenCentral()

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsResourceServerConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsResourceServerConfiguration.kt
@@ -82,6 +82,7 @@ class HmppsResourceServerConfiguration {
 @EnableReactiveMethodSecurity(useAuthorizationManager = false)
 class HmppsReactiveResourceServerConfiguration {
   @ConditionalOnMissingFilterBean
+  @Order(LOWEST_PRECEDENCE)
   @Bean
   fun hmppsSecurityWebFilterChain(http: ServerHttpSecurity, customizer: ResourceServerConfigurationCustomizer): SecurityWebFilterChain = http {
     csrf { disable() }

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsResourceServerConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsResourceServerConfiguration.kt
@@ -12,8 +12,6 @@ import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguratio
 import org.springframework.cache.concurrent.ConcurrentMapCache
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.Ordered.LOWEST_PRECEDENCE
-import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -37,7 +35,6 @@ import uk.gov.justice.hmpps.kotlin.auth.dsl.ResourceServerConfigurationCustomize
 @EnableMethodSecurity(prePostEnabled = true, proxyTargetClass = true)
 class HmppsResourceServerConfiguration {
   @ConditionalOnMissingFilterBean
-  @Order(LOWEST_PRECEDENCE)
   @Bean
   fun hmppsSecurityFilterChain(http: HttpSecurity, customizer: ResourceServerConfigurationCustomizer): SecurityFilterChain = http {
     sessionManagement { SessionCreationPolicy.STATELESS }
@@ -82,7 +79,6 @@ class HmppsResourceServerConfiguration {
 @EnableReactiveMethodSecurity(useAuthorizationManager = false)
 class HmppsReactiveResourceServerConfiguration {
   @ConditionalOnMissingFilterBean
-  @Order(LOWEST_PRECEDENCE)
   @Bean
   fun hmppsSecurityWebFilterChain(http: ServerHttpSecurity, customizer: ResourceServerConfigurationCustomizer): SecurityWebFilterChain = http {
     csrf { disable() }

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsResourceServerConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsResourceServerConfiguration.kt
@@ -39,6 +39,9 @@ class HmppsResourceServerConfiguration {
     sessionManagement { SessionCreationPolicy.STATELESS }
     headers { frameOptions { sameOrigin = true } }
     csrf { disable() }
+    customizer.securityMatcherCustomizer.paths
+      .takeIf { it.isNotEmpty() }
+      ?.also { securityMatcher(*it.toTypedArray()) }
     authorizeHttpRequests {
       customizer.authorizeHttpRequestsCustomizer.dsl
         // override the entire authorizeHttpRequests DSL

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/ResourceServerConfigurationCustomizerDsl.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/ResourceServerConfigurationCustomizerDsl.kt
@@ -83,7 +83,6 @@ class ResourceServerConfigurationCustomizerBuilder : ResourceServerConfiguration
   private var authorizeHttpRequestsCustomizer = AuthorizeHttpRequestsCustomizerBuilder().build()
   private var authorizeExchangeCustomizer = AuthorizeExchangeCustomizerBuilder().build()
   private var oauth2Customizer = Oauth2CustomizerBuilder().build()
-  private var overrideSecurityMatcher = false
   private var overrideAuthorizeHttpRequests = false
   private var overrideAuthorizeExchange = false
   private var customizeAuthorization = false

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/ResourceServerConfigurationCustomizerDsl.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/ResourceServerConfigurationCustomizerDsl.kt
@@ -21,6 +21,12 @@ annotation class ResourceServerConfigurationCustomizerDslMarker
 @ResourceServerConfigurationCustomizerDslMarker
 interface ResourceServerConfigurationCustomizerDsl {
   /**
+   * A customizer for a security matcher. See [SecurityMatcherCustomizerDsl] for more details.
+   */
+  @SecurityMatcherCustomizerDslMarker
+  fun securityMatcher(dsl: SecurityMatcherCustomizerDsl.() -> Unit): SecurityMatcherCustomizer
+
+  /**
    * A customizer for unauthorized request paths. See [UnauthorizedRequestPathCustomizerDsl] for more details.
    */
   @UnauthorizedRequestPathCustomizerDslMarker
@@ -56,6 +62,7 @@ interface ResourceServerConfigurationCustomizerDsl {
 }
 
 class ResourceServerConfigurationCustomizer {
+  lateinit var securityMatcherCustomizer: SecurityMatcherCustomizer
   lateinit var unauthorizedRequestPathsCustomizer: UnauthorizedRequestPathsCustomizer
   lateinit var anyRequestRoleCustomizer: AnyRequestRoleCustomizer
   lateinit var authorizeHttpRequestsCustomizer: AuthorizeHttpRequestsCustomizer
@@ -70,14 +77,21 @@ class ResourceServerConfigurationCustomizer {
 }
 
 class ResourceServerConfigurationCustomizerBuilder : ResourceServerConfigurationCustomizerDsl {
+  private var securityMatcherCustomizer = SecurityMatcherCustomizerBuilder().build()
   private var unauthorizedRequestPathsCustomizer = UnauthorizedRequestPathsCustomizerBuilder().build()
   private var anyRequestRoleCustomizer = AnyRequestRoleCustomizerBuilder().build()
   private var authorizeHttpRequestsCustomizer = AuthorizeHttpRequestsCustomizerBuilder().build()
   private var authorizeExchangeCustomizer = AuthorizeExchangeCustomizerBuilder().build()
   private var oauth2Customizer = Oauth2CustomizerBuilder().build()
+  private var overrideSecurityMatcher = false
   private var overrideAuthorizeHttpRequests = false
   private var overrideAuthorizeExchange = false
   private var customizeAuthorization = false
+
+  override fun securityMatcher(dsl: SecurityMatcherCustomizerDsl.() -> Unit) = SecurityMatcherCustomizerBuilder()
+    .apply(dsl)
+    .build()
+    .also { securityMatcherCustomizer = it }
 
   override fun unauthorizedRequestPaths(dsl: UnauthorizedRequestPathCustomizerDsl.() -> Unit) = UnauthorizedRequestPathsCustomizerBuilder()
     .apply(dsl)
@@ -111,6 +125,7 @@ class ResourceServerConfigurationCustomizerBuilder : ResourceServerConfiguration
 
     return ResourceServerConfigurationCustomizer()
       .also {
+        it.securityMatcherCustomizer = securityMatcherCustomizer
         it.unauthorizedRequestPathsCustomizer = unauthorizedRequestPathsCustomizer
         it.anyRequestRoleCustomizer = anyRequestRoleCustomizer
         it.authorizeHttpRequestsCustomizer = authorizeHttpRequestsCustomizer

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/SecurityMatcherCustomizerDsl.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/SecurityMatcherCustomizerDsl.kt
@@ -15,12 +15,50 @@ annotation class SecurityMatcherCustomizerDslMarker
  *   }
  * ```
  *
- * Note that by default the security matcher is empty so applies to all paths
- */
+ * By default, the security matcher is empty so is considered an `anyRequest` filter that applies to all paths.
+ *
+ * When implementing a security matcher in your customizer, this library won't automatically create the `SecurityFilterChain`
+ * so you need to define one explicitly. Nor will it create an `anyRequest` filter chain so you also need to define one
+ * of these or other paths will not be secured.
+ *
+ * Therefore, an implementation using a security matcher for certain paths might look something like this:
+ *
+ * ```
+ *   // Applies the `specialRole` to any path matching the security matcher
+ *   @Bean
+ *   fun specialResourceServerCustomizer() = ResourceServerConfigurationCustomizer {
+ *     securityMatcher { paths = listOf("/special/\*\*") }
+ *     anyRequestRole { defaultRole = specialRole }
+ *   }
+ *
+ *   // The filter chain using a security matcher needs an `@Order` higher than the HMPPS security filter chain so it's applied first
+ *   @Order(1)
+ *   @Bean
+ *   fun specialSecurityFilterChain(
+ *     http: HttpSecurity,
+ *     specialResourceServerCustomizer: ResourceServerConfigurationCustomizer,
+ *   ): SecurityFilterChain = HmppsResourceServerConfiguration().hmppsSecurityFilterChain(http, specialResourceServerCustomizer)
+ *
+ *   // The HMPPS filter chain does not have an `anyRequestRole` specified so is a catch-all `anyRequest` filter chain
+ *   @Bean
+ *   fun hmppsResourceServerCustomizer() = ResourceServerConfigurationCustomizer {
+ *     unauthorizedRequestPaths {
+ *       addPaths = setOf( "/queue-admin/retry-all-dlqs", )
+ *     }
+ *   }
+ *
+ *   // The HMPPS security filter chain retains the `@Order(LOWEST_PRECEDENCE)` so it's applied last
+ *   @Bean
+ *   fun hmppsSecurityFilterChain(
+ *     http: HttpSecurity,
+ *     hmppsResourceServerCustomizer: ResourceServerConfigurationCustomizer,
+ *   ): SecurityFilterChain = HmppsResourceServerConfiguration().hmppsSecurityFilterChain(http, hmppsResourceServerCustomizer)
+ * ```
+ **/
 @SecurityMatcherCustomizerDslMarker
 interface SecurityMatcherCustomizerDsl {
   /**
-   * Overrides the default empty security marcher for a non-reactive servlet based application.
+   * The `SecurityFilterChain` will only be applied to these paths. Defaults to all paths.
    */
   var paths: List<String>
 }

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/SecurityMatcherCustomizerDsl.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/SecurityMatcherCustomizerDsl.kt
@@ -47,7 +47,7 @@ annotation class SecurityMatcherCustomizerDslMarker
  *     }
  *   }
  *
- *   // The HMPPS security filter chain retains the `@Order(LOWEST_PRECEDENCE)` so it's applied last
+ *   // The HMPPS security filter chain gets the Spring default `@Order(LOWEST_PRECEDENCE)` so it's applied last
  *   @Bean
  *   fun hmppsSecurityFilterChain(
  *     http: HttpSecurity,

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/SecurityMatcherCustomizerDsl.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/dsl/SecurityMatcherCustomizerDsl.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.hmpps.kotlin.auth.dsl
+
+@DslMarker
+annotation class SecurityMatcherCustomizerDslMarker
+
+/**
+ * Part of the [ResourceServerConfigurationCustomizerDsl] DSL.
+ *
+ * To create a new instance of [SecurityMatcherCustomizer], use the [ResourceServerConfigurationCustomizer.Companion.invoke] method, e.g.
+ *
+ * ```
+ *   @Bean
+ *   fun resourceServerCustomizer() = ResourceServerConfigurationCustomizer {
+ *     securityMatcher { listOf("/secured-paths") }
+ *   }
+ * ```
+ *
+ * Note that by default the security matcher is empty so applies to all paths
+ */
+@SecurityMatcherCustomizerDslMarker
+interface SecurityMatcherCustomizerDsl {
+  /**
+   * Overrides the default empty security marcher for a non-reactive servlet based application.
+   */
+  var paths: List<String>
+}
+
+class SecurityMatcherCustomizer(
+  val paths: List<String>,
+)
+
+class SecurityMatcherCustomizerBuilder : SecurityMatcherCustomizerDsl {
+  override var paths: List<String> = emptyList()
+
+  fun build(): SecurityMatcherCustomizer = SecurityMatcherCustomizer(paths)
+}

--- a/readme-contents/SpringResourceServer.md
+++ b/readme-contents/SpringResourceServer.md
@@ -19,6 +19,7 @@ There are various customizations available. These include:
 * setting a default role for authorized endpoints
 * overriding the `authorizeHttpRequests` configuration entirely
 * extending the default auth aware token and token converter
+* defining the paths this security filter chain applies to using a `securityMatcher`
 
 For full details of what is customizable start in subproject `hmpps-kotlin-spring-boot-autoconfigure` package `auth` with file `ResourceServerConfigurationCustomizerDsl.kt`.
 

--- a/release-notes/1.x.md
+++ b/release-notes/1.x.md
@@ -1,3 +1,9 @@
+# 1.4.0
+Add ability to apply a security matcher that limits the paths the security filter chain applies to.
+
+# 1.3.1
+Upgrade to Spring Boot 3.4.3.
+
 # 1.3.0
 Allow overriding the default authentication token converter.
 

--- a/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/resource/SecurityMatcherResource.kt
+++ b/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/resource/SecurityMatcherResource.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.testapp.resource
+package uk.gov.justice.digital.hmpps.testappreactive.resource
 
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
@@ -8,5 +8,5 @@ class SecurityMatcherResource {
 
   // This endpoint is secured by the `customSecurityMatcherCustomizer` in `SecurityMatcherTest.CustomizerConfiguration`
   @GetMapping("/protected-by-custom-security-matcher")
-  fun getSecurityMatcherEndpoint(): String = "OK"
+  suspend fun getSecurityMatcherEndpoint(): String = "OK"
 }

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/auth/customizer/SecurityMatcherTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/auth/customizer/SecurityMatcherTest.kt
@@ -32,7 +32,7 @@ class SecurityMatcherTest : IntegrationTestBase() {
       anyRequestRole { defaultRole = "CUSTOM_SECURITY_MATCHER" }
     }
 
-    // And this is the security filter that uses the security marcher customizer
+    // And this is the security filter that uses the security matcher customizer
     @Bean
     fun securityMatcherSecurityFilterChain(
       http: ServerHttpSecurity,

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/auth/customizer/SecurityMatcherTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/auth/customizer/SecurityMatcherTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.testapp.integration.auth.customizer
+package uk.gov.justice.digital.hmpps.testappreactive.integration.auth.customizer
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -7,10 +7,10 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.web.SecurityFilterChain
-import uk.gov.justice.digital.hmpps.testapp.integration.IntegrationTestBase
-import uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.web.server.SecurityWebFilterChain
+import uk.gov.justice.digital.hmpps.testappreactive.integration.IntegrationTestBase
+import uk.gov.justice.hmpps.kotlin.auth.HmppsReactiveResourceServerConfiguration
 import uk.gov.justice.hmpps.kotlin.auth.dsl.ResourceServerConfigurationCustomizer
 import java.time.LocalDate
 
@@ -35,9 +35,9 @@ class SecurityMatcherTest : IntegrationTestBase() {
     // And this is the security filter that uses the security marcher customizer
     @Bean
     fun securityMatcherSecurityFilterChain(
-      http: HttpSecurity,
+      http: ServerHttpSecurity,
       @Qualifier("customSecurityMatcherCustomizer") customizer: ResourceServerConfigurationCustomizer,
-    ): SecurityFilterChain = HmppsResourceServerConfiguration().hmppsSecurityFilterChain(http, customizer)
+    ): SecurityWebFilterChain = HmppsReactiveResourceServerConfiguration().hmppsSecurityWebFilterChain(http, customizer)
 
     // We have to explicitly define a standard customizer - this gets the library default and is a backstop for requests not
     // matching the security matcher, so would have the standard customizer for the app e.g. including unauthorized paths etc
@@ -48,9 +48,9 @@ class SecurityMatcherTest : IntegrationTestBase() {
     // only use the custom resource server defined above
     @Bean
     fun hmppsSecurityFilterChain(
-      http: HttpSecurity,
+      http: ServerHttpSecurity,
       @Qualifier("hmppsCustomizer") customizer: ResourceServerConfigurationCustomizer,
-    ): SecurityFilterChain = HmppsResourceServerConfiguration().hmppsSecurityFilterChain(http, customizer)
+    ): SecurityWebFilterChain = HmppsReactiveResourceServerConfiguration().hmppsSecurityWebFilterChain(http, customizer)
   }
 
   @Test
@@ -105,7 +105,7 @@ class SecurityMatcherTest : IntegrationTestBase() {
   fun `should be OK calling endpoints relying on the security filter chain with no security matcher`() {
     webTestClient.get()
       .uri("/time")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEST_APP")))
+      .headers(setAuthorisation(roles = listOf("ROLE_TEST_APP_REACTIVE")))
       .exchange()
       .expectStatus()
       .isOk

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/resource/SecurityMatcherResource.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/resource/SecurityMatcherResource.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.testapp.resource
+
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SecurityMatcherResource {
+
+  // This endpoint is secured by the `customSecurityMatcherCustomizer` in `SecurityMatcherTest.CustomizerConfiguration`
+  @RequestMapping("/protected-by-custom-security-matcher")
+  fun getSecurityMatcherEndpoint(): String = "OK"
+}

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/auth/customizer/SecurityMatcherTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/auth/customizer/SecurityMatcherTest.kt
@@ -32,7 +32,7 @@ class SecurityMatcherTest : IntegrationTestBase() {
       anyRequestRole { defaultRole = "CUSTOM_SECURITY_MATCHER" }
     }
 
-    // And this is the security filter that uses the security marcher customizer
+    // And this is the security filter that uses the security matcher customizer
     @Bean
     fun securityMatcherSecurityFilterChain(
       http: HttpSecurity,

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/auth/customizer/SecurityMatcherTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/auth/customizer/SecurityMatcherTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.testapp.integration.auth.customizer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+import uk.gov.justice.digital.hmpps.testapp.integration.IntegrationTestBase
+import uk.gov.justice.hmpps.kotlin.auth.HmppsResourceServerConfiguration
+import uk.gov.justice.hmpps.kotlin.auth.dsl.ResourceServerConfigurationCustomizer
+import java.time.LocalDate
+
+@Import(SecurityMatcherTest.CustomizerConfiguration::class)
+@SpringBootTest(
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  // allow overriding of the ResourceServerConfigurationCustomizer bean definition
+  properties = ["spring.main.allow-bean-definition-overriding=true"],
+)
+class SecurityMatcherTest : IntegrationTestBase() {
+  @TestConfiguration
+  class CustomizerConfiguration {
+
+    // Define a customizer that only applies to certain endpoints using the custom security matcher
+    @Bean
+    fun customSecurityMatcherCustomizer() = ResourceServerConfigurationCustomizer {
+      // Add a custom security matcher which requires the ACTIVE_CASELOAD role
+      securityMatcher { paths = listOf("/protected-by-custom-security-matcher") }
+      anyRequestRole { defaultRole = "CUSTOM_SECURITY_MATCHER" }
+    }
+
+    // And this is the security filter that uses the security marcher customizer
+    @Bean
+    fun securityMatcherSecurityFilterChain(
+      http: HttpSecurity,
+      @Qualifier("customSecurityMatcherCustomizer") customizer: ResourceServerConfigurationCustomizer,
+    ): SecurityFilterChain = HmppsResourceServerConfiguration().hmppsSecurityFilterChain(http, customizer)
+
+    // We have to explicitly define a standard customizer - this gets the library default and is a backstop for requests not
+    // matching the security matcher, so would have the standard customizer for the app e.g. including unauthorized paths etc
+    @Bean
+    fun hmppsCustomizer() = ResourceServerConfigurationCustomizer {}
+
+    // And we also have to explicitly define the standard filter chain or the library will "get out of the way" and
+    // only use the custom resource server defined above
+    @Bean
+    fun hmppsSecurityFilterChain(
+      http: HttpSecurity,
+      @Qualifier("hmppsCustomizer") customizer: ResourceServerConfigurationCustomizer,
+    ): SecurityFilterChain = HmppsResourceServerConfiguration().hmppsSecurityFilterChain(http, customizer)
+  }
+
+  @Test
+  fun `should return OK for an unauthorized endpoint`() {
+    webTestClient.get()
+      .uri("/info")
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  @Test
+  fun `should return unauthorized for a protected endpoint`() {
+    webTestClient.get()
+      .uri("/active-caseload")
+      .exchange()
+      .expectStatus()
+      .isUnauthorized
+  }
+
+  @Test
+  fun `should return forbidden without a role`() {
+    webTestClient.get()
+      .uri("/active-caseload")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should return forbidden with wrong role`() {
+    webTestClient.get()
+      .uri("/active-caseload")
+      .headers(setAuthorisation(roles = listOf("ROLE_WRONG")))
+      .exchange()
+      .expectStatus()
+      .isForbidden
+  }
+
+  @Test
+  fun `should allow access to the protected endpoint`() {
+    webTestClient.get()
+      .uri("/protected-by-custom-security-matcher")
+      .headers(setAuthorisation(roles = listOf("ROLE_CUSTOM_SECURITY_MATCHER")))
+      .exchange()
+      .expectStatus()
+      .isOk
+  }
+
+  @Test
+  fun `should be OK calling endpoints relying on the security filter chain with no security matcher`() {
+    webTestClient.get()
+      .uri("/time")
+      .headers(setAuthorisation(roles = listOf("ROLE_TEST_APP")))
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("$").value<String> {
+        assertThat(it).startsWith("${LocalDate.now()}")
+      }
+  }
+}


### PR DESCRIPTION
Adds a configurable security matcher to the security filter chain provided by this library. By default there is no security filter so the filter chain provided applies to all paths.

Nice to haves?

- can we check in the library if there is more than one customizer bean, and if so then we need to create a security filter for each (meaning people wanting multiple security filters in the same app don't have the hassle of creating their own security filter chains)

- can we add validation to check that there is at least one of our HMPPS security filter chains that matches `anyRequest`? I thought Spring did this but it doesn't, it just warns if there are security filter chains with a securityMatcher lower down the chain than the anyRequest security filter chain.