### PR TITLE
pgp HAAR 4236 username aware token request

### DIFF
--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
@@ -248,6 +248,21 @@ fun usernameAwareTokenRequestOAuth2AuthorizedClientManager(
   }
 }
 
+/**
+ * This method generates an instance of the [AuthorizedClientServiceReactiveOAuth2AuthorizedClientManager]
+ * class configured to include the name of the authenticated principal in the OAuth2ClientCredentialsGrantRequest. This is designed to be used as part of
+ * a request scoped web client where the authenticated principal can vary between requests.
+ *
+ * A [WebClientReactiveClientCredentialsTokenResponseClient] is configured with an exchange filter function to extract
+ * the principal name from the current [org.springframework.security.core.Authentication] object in the [ReactiveSecurityContextHolder]
+ * and set it as the **username** parameter on the client credentials token request.
+ *
+ * This should be used for web clients where the user context is required.
+ *
+ * @param reactiveClientRegistrationRepository
+ * @param reactiveOAuth2AuthorizedClientService
+ * @param clientCredentialsRequestTimeout
+ */
 fun reactiveUsernameAwareTokenRequestOAuth2AuthorizedClientManager(
   reactiveClientRegistrationRepository: ReactiveClientRegistrationRepository,
   reactiveOAuth2AuthorizedClientService: ReactiveOAuth2AuthorizedClientService,

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
@@ -144,7 +144,7 @@ private fun createAccessTokenResponseClient(clientCredentialsClientTimeout: Dura
       }
       .defaultStatusHandler(OAuth2ErrorResponseErrorHandler())
       .requestFactory(requestFactory)
-      .build()
+  .build()
 
     setRestClient(restClient)
   }

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
@@ -122,32 +122,30 @@ class HmppsReactiveWebClientConfiguration {
   ): ReactiveOAuth2AuthorizedClientProvider = builder.reactiveOAuth2AuthorizedClientProvider(Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS))
 }
 
-fun oAuth2AuthorizedClientProvider(clientCredentialsClientTimeout: Duration): OAuth2AuthorizedClientProvider =
-  OAuth2AuthorizedClientProviderBuilder
-    .builder()
-    .clientCredentials { it.accessTokenResponseClient(createAccessTokenResponseClient(clientCredentialsClientTimeout)) }
-    .build()
-
-private fun createAccessTokenResponseClient(clientCredentialsClientTimeout: Duration): RestClientClientCredentialsTokenResponseClient =
-  RestClientClientCredentialsTokenResponseClient().kotlinApply {
-    val requestFactory = ReactorClientHttpRequestFactory().kotlinApply {
-      setReadTimeout(clientCredentialsClientTimeout)
-    }
-
-    // code duplicated from AbstractRestClientOAuth2AccessTokenResponseClient.restClient
-    // so that we can set our requestFactory
-    val restClient = RestClient.builder()
-      .messageConverters { messageConverters: MutableList<HttpMessageConverter<*>?> ->
-        messageConverters.clear()
-        messageConverters.add(FormHttpMessageConverter())
-        messageConverters.add(OAuth2AccessTokenResponseHttpMessageConverter())
-      }
-      .defaultStatusHandler(OAuth2ErrorResponseErrorHandler())
-      .requestFactory(requestFactory)
+fun oAuth2AuthorizedClientProvider(clientCredentialsClientTimeout: Duration): OAuth2AuthorizedClientProvider = OAuth2AuthorizedClientProviderBuilder
+  .builder()
+  .clientCredentials { it.accessTokenResponseClient(createAccessTokenResponseClient(clientCredentialsClientTimeout)) }
   .build()
 
-    setRestClient(restClient)
+private fun createAccessTokenResponseClient(clientCredentialsClientTimeout: Duration): RestClientClientCredentialsTokenResponseClient = RestClientClientCredentialsTokenResponseClient().kotlinApply {
+  val requestFactory = ReactorClientHttpRequestFactory().kotlinApply {
+    setReadTimeout(clientCredentialsClientTimeout)
   }
+
+  // code duplicated from AbstractRestClientOAuth2AccessTokenResponseClient.restClient
+  // so that we can set our requestFactory
+  val restClient = RestClient.builder()
+    .messageConverters { messageConverters: MutableList<HttpMessageConverter<*>?> ->
+      messageConverters.clear()
+      messageConverters.add(FormHttpMessageConverter())
+      messageConverters.add(OAuth2AccessTokenResponseHttpMessageConverter())
+    }
+    .defaultStatusHandler(OAuth2ErrorResponseErrorHandler())
+    .requestFactory(requestFactory)
+    .build()
+
+  setRestClient(restClient)
+}
 
 fun WebClient.Builder.reactiveOAuth2AuthorizedClientProvider(clientCredentialsClientTimeout: Duration): ReactiveOAuth2AuthorizedClientProvider {
   val accessTokenResponseClient = WebClientReactiveClientCredentialsTokenResponseClient().kotlinApply {

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfigurationTest.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfigurationTest.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.hmpps.kotlin.auth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.client.reactive.ClientHttpRequest
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.ReactiveSecurityContextHolder
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.web.reactive.function.BodyInserter
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
+import reactor.core.publisher.Mono
+import java.net.URI
+
+@ExtendWith(MockitoExtension::class)
+class HmppsWebClientConfigurationTest {
+
+  @Nested
+  inner class ExchangeFilterFunctionTests {
+    @Mock
+    private lateinit var mockAuthentication: Authentication
+
+    @Mock
+    private lateinit var mockSecurityContext: SecurityContext
+
+    private lateinit var mockReactiveSecurityContextHolder: MockedStatic<ReactiveSecurityContextHolder>
+
+    @BeforeEach()
+    fun setup() {
+      mockReactiveSecurityContextHolder = mockStatic(ReactiveSecurityContextHolder::class.java)
+      mockReactiveSecurityContextHolder.`when`<Mono<SecurityContext>> { ReactiveSecurityContextHolder.getContext() }
+        .thenReturn(Mono.just(mockSecurityContext))
+    }
+
+    @AfterEach
+    fun teardown() {
+      mockReactiveSecurityContextHolder.close()
+    }
+
+    @Test
+    fun `usernameInjectingReactiveExchangeFilterFunction should inject username into form body`() {
+      val testUser = "test-user"
+      whenever(mockSecurityContext.authentication).thenReturn(mockAuthentication)
+      whenever(mockAuthentication.name).thenReturn(testUser)
+
+      val body = runFilterOnRequestAndReturnCapturedBody(usernameInjectingReactiveExchangeFilterFunction())
+
+      assertThat(body is BodyInserters.FormInserter<*>)
+      assertThat(body.toString().contains("grant_type=client_credentials"))
+      assertThat(body.toString().contains("username=$testUser"))
+    }
+
+    @Test
+    fun `usernameInjectingReactiveExchangeFilterFunction should not inject an empty username into the form body`() {
+      whenever(mockSecurityContext.authentication).thenReturn(mockAuthentication)
+      whenever(mockAuthentication.name).thenReturn("")
+
+      val body = runFilterOnRequestAndReturnCapturedBody(usernameInjectingReactiveExchangeFilterFunction())
+
+      assertThat(body is BodyInserters.FormInserter<*>)
+      assertThat(body.toString().contains("grant_type=client_credentials"))
+      assertThat(!body.toString().contains("username"))
+    }
+
+    @Test
+    fun `usernameInjectingReactiveExchangeFilterFunction should handle a null authentication object`() {
+      whenever(mockSecurityContext.authentication).thenReturn(null)
+
+      val body = runFilterOnRequestAndReturnCapturedBody(usernameInjectingReactiveExchangeFilterFunction())
+
+      assertThat(body is BodyInserters.FormInserter<*>)
+      assertThat(body.toString().contains("grant_type=client_credentials"))
+      assertThat(!body.toString().contains("username"))
+    }
+
+    private fun runFilterOnRequestAndReturnCapturedBody(filterToTest: ExchangeFilterFunction): BodyInserter<*, in ClientHttpRequest>? {
+      val dummyClientRequest = ClientRequest
+        .create(HttpMethod.POST, URI.create("auth/oauth/token"))
+        .body(BodyInserters.fromFormData("grant_type", "client_credentials"))
+        .build()
+
+      var capturedRequest: ClientRequest? = null
+
+      val exchangeFunction = ExchangeFunction { req ->
+        capturedRequest = req
+        Mono.just(ClientResponse.create(HttpStatus.OK).build())
+      }
+
+      filterToTest.filter(dummyClientRequest, exchangeFunction).block()
+
+      return capturedRequest?.body()
+    }
+  }
+}

--- a/readme-contents/WebClients.md
+++ b/readme-contents/WebClients.md
@@ -10,7 +10,10 @@ the name of the authenticate principal in the Spring `SecurityContextHolder`. Th
 * an extension function to `WebClient.Builder` called `authorisedWebClient` for creating `WebClient`s that are authorized with an OAuth2 token
 * an extension function to `WebClient.Builder` called `healthWebClient` for creating `WebClient`s that are unauthorized and are used to call `/health` endpoints
 * a default timeout of 30 seconds when fetching client credentials 
-
+* a method for constructing a "usernameAware" `OAuth2AuthorizedClientManager`. The `OAuth2AuthorizedClientManager` can be added to a request scoped
+`WebClient` and will add the username of the authenticated principal as a parameter in the client credentials token request. This is
+used to embed the username in context within the token so it can be passed to downstream services.
+* 
 For an example of how to create `WebClient` instances see class `WebClientConfiguration` in subproject `test-app`.
 
 > **NOTE** If your application requires client credentials tokens to be cached per principal e.g. if the principal name is being injected into the token request
@@ -23,6 +26,9 @@ the name of the authenticate principal in the Spring `ReactiveSecurityContextHol
 * an extension function to `WebClient.Builder` called `reactiveAuthorisedWebClient` for creating `WebClient`s that are authorized with an OAuth2 token
 * an extension function to `WebClient.Builder` called `reactiveHealthWebClient` for creating `WebClient`s that are unauthorized and are used to call /health endpoints
 * a default timeout of 30 seconds when fetching client credentials
+* a method for constructing a "usernameAware" `ReactiveOAuth2AuthorizedClientManager`. The `ReactiveOAuth2AuthorizedClientManager` utilises an
+exchange filter function to dynamically add the username of the authenticated principal as a parameter in the client credentials token request. This is 
+used to embed the username in context within the token so it can be passed to downstream services.
 
 For an example of how to create `WebClient` instances see class `WebClientConfiguration` in subproject `test-app-reactive`
 

--- a/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/config/WebClientConfiguration.kt
+++ b/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/config/WebClientConfiguration.kt
@@ -4,9 +4,12 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository
 import org.springframework.web.reactive.function.client.WebClient
 import uk.gov.justice.hmpps.kotlin.auth.reactiveAuthorisedWebClient
 import uk.gov.justice.hmpps.kotlin.auth.reactiveHealthWebClient
+import uk.gov.justice.hmpps.kotlin.auth.reactiveUsernameAwareTokenRequestOAuth2AuthorizedClientManager
 import java.time.Duration
 
 @Configuration
@@ -24,4 +27,26 @@ class WebClientConfiguration(
 
   @Bean
   fun prisonApiWebClient(reactiveAuthorizedClientManager: ReactiveOAuth2AuthorizedClientManager, builder: WebClient.Builder): WebClient = builder.reactiveAuthorisedWebClient(reactiveAuthorizedClientManager, registrationId = "prison-api", url = prisonApiBaseUri, timeout)
+
+  /**
+   * This [org.springframework.web.reactive.function.client.WebClient] uses a
+   * [org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager] configured with an exchange
+   * filter function to extract the authenticated principal on each request and inject it as the **username** parameter in the
+   * token request call.
+   */
+  @Bean
+  fun usernameAwarePrisonApiWebClient(
+    reactiveClientRegistrationRepository: ReactiveClientRegistrationRepository,
+    reactiveOAuth2AuthorizedClientService: ReactiveOAuth2AuthorizedClientService,
+    builder: WebClient.Builder,
+  ): WebClient = builder.reactiveAuthorisedWebClient(
+    reactiveUsernameAwareTokenRequestOAuth2AuthorizedClientManager(
+      reactiveClientRegistrationRepository,
+      reactiveOAuth2AuthorizedClientService,
+      timeout,
+    ),
+    registrationId = "prison-api",
+    url = prisonApiBaseUri,
+    timeout,
+  )
 }

--- a/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/resource/TestAppReactiveResource.kt
+++ b/test-app-reactive/src/main/kotlin/uk/gov/justice/digital/hmpps/testappreactive/resource/TestAppReactiveResource.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.testappreactive.resource
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.testappreactive.service.PrisonApiService
 import java.time.LocalDateTime
@@ -16,6 +17,9 @@ class TestAppReactiveResource(private val prisonApiService: PrisonApiService) {
 
   @RequestMapping("/prisoner/{prisonNumber}/booking")
   suspend fun getOffenderBookingId(@PathVariable prisonNumber: String) = prisonApiService.getOffenderBooking(prisonNumber)
+
+  @RequestMapping("/prisoner/{prisonNumber}/booking", params = ["userContext"])
+  suspend fun getOffenderBookingIdWithUserContext(@PathVariable prisonNumber: String, @RequestParam userContext: Boolean) = prisonApiService.getOffenderBookingWithUserInContext(prisonNumber)
 
   @RequestMapping("/auth/token")
   suspend fun getAuthToken() = prisonApiService.getAuthToken()

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/resource/TestAppReactiveResourceIntegrationTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/resource/TestAppReactiveResourceIntegrationTest.kt
@@ -153,4 +153,30 @@ class TestAppReactiveResourceIntegrationTest : IntegrationTestBase() {
       HmppsAuthApiExtension.hmppsAuth.assertNumberStubGrantTokenCalls(1)
     }
   }
+
+  @Nested
+  inner class BookingEndpointWithUserContext {
+    @BeforeEach
+    fun setup() {
+      HmppsAuthApiExtension.hmppsAuth.resetAll()
+      // The HMPPS Auth Token Endpoint stub will only match a request containing the provided
+      // username in the request body.
+      HmppsAuthApiExtension.hmppsAuth.stubUsernameEnhancedGrantToken("AUTH_ADM")
+      PrisonApiExtension.prisonApi.stubGetPrisonerLatestBooking("ABC123C")
+    }
+
+    @Test
+    fun `should pass username in context when requesting client credentials token`() {
+      webTestClient.get().uri { uriBuilder ->
+        uriBuilder
+          .path("/prisoner/{prisonNumber}/booking")
+          .queryParam("userContext", true)
+          .build("ABC123C")
+      }
+        .headers(setAuthorisation(roles = listOf("ROLE_TEST_APP_REACTIVE")))
+        .exchange()
+        .expectStatus()
+        .isOk
+    }
+  }
 }

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/wiremock/HmppsAuthMockServer.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/testappreactive/integration/wiremock/HmppsAuthMockServer.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.testappreactive.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.exactly
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
@@ -74,6 +75,26 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
           .withBody(if (status == 200) """{"status":"UP"}""" else """{"status":"DOWN"}""")
           .withStatus(status),
       ),
+    )
+  }
+
+  fun stubUsernameEnhancedGrantToken(username: String) {
+    stubFor(
+      post(urlEqualTo("/auth/oauth/token"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+        .withRequestBody(containing("username=$username"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """
+                {
+                  "token_type": "bearer",
+                  "access_token": "ABCDE"
+                }
+              """.trimIndent(),
+            ),
+        ),
     )
   }
 

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/resource/TestAppResource.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/resource/TestAppResource.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.testapp.resource
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.testapp.service.PrisonApiService
 import java.time.LocalDateTime
@@ -16,6 +17,9 @@ class TestAppResource(private val prisonApiService: PrisonApiService) {
 
   @RequestMapping("/prisoner/{prisonNumber}/booking")
   fun getOffenderBooking(@PathVariable prisonNumber: String) = prisonApiService.getOffenderBooking(prisonNumber)
+
+  @RequestMapping("/prisoner/{prisonNumber}/booking", params = ["userContext"])
+  fun getOffenderBookingIdWithUserContext(@PathVariable prisonNumber: String, @RequestParam userContext: Boolean) = prisonApiService.getOffenderBookingWithUserInContext(prisonNumber)
 
   @RequestMapping("/auth/token")
   fun getAuthToken() = prisonApiService.getAuthToken()

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/service/PrisonApiService.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/testapp/service/PrisonApiService.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.hmpps.kotlin.auth.HmppsAuthenticationHolder
 @Service
 class PrisonApiService(
   private val prisonApiWebClient: WebClient,
+  private val usernameAwarePrisonApiWebClient: WebClient,
   private val hmppsAuthenticationHolder: HmppsAuthenticationHolder,
 ) {
 
@@ -16,6 +17,13 @@ class PrisonApiService(
     // Note that we don't use string interpolation here ("/$prisonNumber").
     // This is important - using string interpolation causes each uri to be added as a separate path in app insights and
     // you'll run out of memory in your app
+    .uri("/api/offender/{prisonNumber}", prisonNumber)
+    .retrieve()
+    .bodyToMono(OffenderBooking::class.java)
+    .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
+    .block()
+
+  fun getOffenderBookingWithUserInContext(prisonNumber: String): OffenderBooking? = usernameAwarePrisonApiWebClient.get()
     .uri("/api/offender/{prisonNumber}", prisonNumber)
     .retrieve()
     .bodyToMono(OffenderBooking::class.java)

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/resource/TestAppResourceIntegrationTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/resource/TestAppResourceIntegrationTest.kt
@@ -4,8 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.testapp.health.HmppsAuthHealthPing
 import uk.gov.justice.digital.hmpps.testapp.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.testapp.integration.wiremock.HmppsAuthApiExtension
 import uk.gov.justice.digital.hmpps.testapp.integration.wiremock.PrisonApiExtension

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/wiremock/HmppsAuthMockServer.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/wiremock/HmppsAuthMockServer.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.testapp.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
-import com.github.tomakehurst.wiremock.client.WireMock.exactly
 import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.exactly
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/wiremock/HmppsAuthMockServer.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/testapp/integration/wiremock/HmppsAuthMockServer.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.testapp.integration.wiremock
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.exactly
+import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
@@ -79,5 +80,25 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun assertNumberStubGrantTokenCalls(numberOfCalls: Int) {
     verify(exactly(numberOfCalls), postRequestedFor(urlPathMatching("/auth/oauth/token")))
+  }
+
+  fun stubUsernameEnhancedGrantToken(username: String) {
+    stubFor(
+      post(urlEqualTo("/auth/oauth/token"))
+        .withRequestBody(containing("grant_type=client_credentials"))
+        .withRequestBody(containing("username=$username"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """
+                {
+                  "token_type": "bearer",
+                  "access_token": "ABCDE"
+                }
+              """.trimIndent(),
+            ),
+        ),
+    )
   }
 }


### PR DESCRIPTION
- **HAAR-4236: Methods to generate usernameAwareTokenRequestOAuth2AuthorizedClientManager and a reactiveUsernameAwareTokenRequestOAuth2AuthorizedClientManager**
- **HAAR-4236: Added doc string for reactiveUsernameAwareTokenRequestOAuth2AuthorizedClientManager**
- **HAAR-4236: Example usage of the usernameAwareTokenRequestOAuth2AuthorizedClientManager added to the servlet based test app.**
- **HAAR-4236: Example usage of the reactiveUsernameAwareTokenRequestOAuth2AuthorizedClientManager added to the reactive test app.**
- **HAAR-4236: Switched from deprecated DefaultClientCredentialsTokenResponseClient to RestClientClientCredentialsTokenResponseClient**
- **HAAR-4236: Unused imports removed.**
- **HAAR-4236: WebClients.md updated to include information on the username aware AuthorizedClientManagers**
