### PR TITLE
Add a general purpose, proxy-aware web client for unauthenticated calls to public endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "3.0.0-beta"
+  version = "3.0.0-beta2"
 
   repositories {
     mavenCentral()

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/kotlin/auth/HmppsWebClientConfiguration.kt
@@ -190,6 +190,13 @@ fun WebClient.Builder.healthWebClient(
   .clientConnector(ReactorClientHttpConnector(proxyAwareHttpClient(healthTimeout)))
   .build()
 
+fun WebClient.Builder.unauthenticatedWebClient(
+  url: String,
+  timeout: Duration = Duration.ofSeconds(DEFAULT_TIMEOUT_SECONDS),
+): WebClient = baseUrl(url)
+  .clientConnector(ReactorClientHttpConnector(proxyAwareHttpClient(timeout)))
+  .build()
+
 fun WebClient.Builder.reactiveAuthorisedWebClient(
   authorizedClientManager: ReactiveOAuth2AuthorizedClientManager,
   registrationId: String,

--- a/hmpps-kotlin-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/kotlin/auth/UnauthenticatedWebClientTest.kt
+++ b/hmpps-kotlin-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/kotlin/auth/UnauthenticatedWebClientTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.hmpps.kotlin.auth
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.client.WebClient
+import java.time.Duration
+
+class UnauthenticatedWebClientTest {
+
+  @Test
+  fun `should create an unauthenticatedWebClient with baseUrl`() {
+    val baseUrl = "https://example.com"
+    val timeout = Duration.ofSeconds(20)
+    val builder = WebClient.builder()
+
+    val webClient = builder.unauthenticatedWebClient(baseUrl, timeout)
+
+    assertThat(webClient).isNotNull
+  }
+
+  @Test
+  fun `should use default timeout when not specified`() {
+    val baseUrl = "https://example.com"
+    val builder = WebClient.builder()
+
+    val webClient = builder.unauthenticatedWebClient(baseUrl)
+
+    assertThat(webClient).isNotNull
+  }
+
+  @Test
+  fun `should be able to build requests with the returned client`() {
+    val baseUrl = "https://api.example.com"
+    val builder = WebClient.builder()
+    val webClient = builder.unauthenticatedWebClient(baseUrl, Duration.ofSeconds(10))
+
+    // Verify the client can be used to build a request
+    val requestSpec = webClient.get().uri("/test")
+
+    assertThat(requestSpec).isNotNull
+  }
+}

--- a/release-notes/3.x.md
+++ b/release-notes/3.x.md
@@ -18,3 +18,15 @@ before the call to the oauth2 filter function.
 
 Note that this bug only affects servlet environments, reactive applications will be unaffected and workaround is
 required.
+
+Add a general purpose, proxy-aware `unauthenticatedWebClient` extension function on `WebClient.Builder`.
+
+This provides a proxy-aware `WebClient` for outbound calls to public endpoints that do not require OAuth2 authentication (for example public government APIs). It uses the same `proxyAwareHttpClient` setup as `authorisedWebClient` and `healthWebClient`, reading `HTTPS_PROXY` and `NO_PROXY` from the environment automatically.
+
+Use it in place of constructing a `WebClient` directly via the static `WebClient.builder()` factory:
+
+```kotlin
+@Bean
+fun myApiWebClient(builder: WebClient.Builder) = builder
+    .unauthenticatedWebClient(myApiUrl, apiTimeout)
+```


### PR DESCRIPTION
The Kotlin lib doesn't current provide a general purpose, proxy-aware web client for unauthenticated calls. As such its common in many hmpps kotlin projects to revert to constructing a web client directly by calling
`WebClient.builder()`
for that purpose.

Web clients created this way won't have the benefit of the proxy-awareness inherent in the clients injected from the hmpps-kotlin-lib. By creating this function to provide one, we provide teams with a simple means to use a hmpps-kotlin-lib client that has proxy awareness built in. It also allows additional features to be made standard in future by updating the library rather than each application.

The health client is very similar. That provides a proxy-aware, unauthenticated web client. It is however named to be specific to the purpose of calling health endpoints. As such, were its default to be modified in the library in future, this might have unwanted side effects on non-health traffic. As such, a general-purpose equivalent remains the cleanest approach. 

Usage example (when fetching www.gov.uk/bank-holidays.json)
https://github.com/ministryofjustice/hmpps-activities-management-api/pull/2187
